### PR TITLE
scale the cluster, but use m5 instances

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -19,5 +19,12 @@ module "eks" {
       minimum_size  = 3
       maximum_size  = 3
     }
+
+    m5-general = {
+      instance_type = "m5.xlarge"
+      desired_size  = 6
+      minimum_size  = 6
+      maximum_size  = 6
+    }
   }
 }


### PR DESCRIPTION
Scales the cluster, but uses the m5 instances to do so. These are cheaper to run at on-demand prices.

The new instances will join the cluster without issue even-though they're in a different worker group