### PR TITLE
bring terraform-covidapihub under config control

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -8,5 +8,6 @@ module "github" {
 
   repositories = [
     "datasource-inshift",
+    "terraform-covidapihub",
   ]
 }

--- a/modules/github/repositories.tf
+++ b/modules/github/repositories.tf
@@ -15,7 +15,7 @@ resource "github_repository" "repository" {
   has_projects       = false
   has_wiki           = false
   topics             = []
-  auto_init          = true
+  auto_init          = false
 }
 
 resource "github_branch_protection" "master" {


### PR DESCRIPTION
@chrisbsmith and @hiromis, this add this repo to configuration control and should enable codeowner merges.

Note that I disabled auto init as it will prevent us from importing existing repos in the future.  This will reset the data-insight repo but that is not heavily used.  @kaitmore to confirm that a temporary down time on that one is okay.