### PR TITLE
Adding count.index to fix the error

### DIFF
--- a/modules/eks/network.tf
+++ b/modules/eks/network.tf
@@ -81,9 +81,7 @@ resource "aws_route_table_association" "worker-egress" {
 }
 
 resource "aws_network_interface" "proxy-nlb-master-nic" {
-  count = length(aws_subnet.master)
-  
-  subnet_id   = aws_subnet.master[count.index].id
+  subnet_id   = aws_subnet.master[0].id
 }
 
 resource "aws_eip" "nlb-eip-master" {


### PR DESCRIPTION
To fix this issue:

```
Terraform v0.12.24
Configuring remote state backend...
Initializing Terraform configuration...
2020/06/09 19:44:39 [DEBUG] Using modified User-Agent: Terraform/0.12.24 TFC/b239724cfc
Error: Missing resource instance key
  on modules/eks/network.tf line 84, in resource "aws_network_interface" "proxy-nlb-master-nic":
  84:   subnet_id   = aws_subnet.master.id
Because aws_subnet.master has "count" set, its attributes must be accessed on
specific instances.
For example, to correlate with indices of a referring resource, use:
    aws_subnet.master[count.index]
```