### PR TITLE
Subtract 6 worker nodes

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -14,9 +14,9 @@ module "eks" {
   worker_groups = {
     m5-general = {
       instance_type = "m5.xlarge"
-      desired_size  = 15
-      minimum_size  = 15
-      maximum_size  = 15
+      desired_size  = 9
+      minimum_size  = 9
+      maximum_size  = 9
     }
   }
 }


### PR DESCRIPTION
These have already been drained with kubectl and deleted via the AWS
console. This PR should be a no-op that makes terraform match.
