### PR TITLE
modules for standalone VPC and EKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# editors
+.idea
+
+# generated files
+.terraform
+*.tfstate
+*.out
+

--- a/dev_env.tf
+++ b/dev_env.tf
@@ -1,0 +1,17 @@
+
+module "dev1_network" {
+  source       = "./modules/network"
+  network_name = "dev1"
+  vpc_cidr     = "10.1.0.0/16"
+}
+
+module "dev1_cluster" {
+  source             = "./modules/eks_standalone"
+  cluster_name       = "dev1"
+  k8s_version        = 1.16
+  num_workers        = 3
+  instance_types     = ["m5.large"]
+  private_subnet_ids = module.dev1_network.private_subnet_ids
+  public_subnet_ids  = module.dev1_network.public_subnet_ids
+}
+

--- a/github.tf
+++ b/github.tf
@@ -4,6 +4,7 @@ module "github" {
   administrators = [
     "chrisbsmith",
     "kaitmore",
+    "dontlaugh",
   ]
 
   members = [

--- a/modules/eks_standalone/cluster.tf
+++ b/modules/eks_standalone/cluster.tf
@@ -1,0 +1,45 @@
+
+resource "aws_eks_cluster" "cluster" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster_role.arn
+
+  version = var.k8s_version
+
+  vpc_config {
+    endpoint_private_access = true
+    endpoint_public_access  = true
+    subnet_ids              = concat(var.private_subnet_ids, var.public_subnet_ids)
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.AmazonEKSServicePolicy
+  ]
+}
+
+resource "aws_eks_node_group" "node_group" {
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = var.cluster_name
+  node_role_arn   = aws_iam_role.node_group.arn
+  subnet_ids      = var.private_subnet_ids
+  version         = var.k8s_version
+  instance_types  = var.instance_types
+
+  scaling_config {
+    desired_size = var.num_workers
+    max_size     = var.num_workers
+    min_size     = var.num_workers
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.AmazonEC2ContainerRegistryReadOnly,
+  ]
+}
+
+

--- a/modules/eks_standalone/iam.tf
+++ b/modules/eks_standalone/iam.tf
@@ -1,0 +1,69 @@
+
+resource "aws_iam_role" "node_group" {
+  name = "${var.cluster_name}-eks-node-group"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role" "cluster_role" {
+  name = "${var.cluster_name}-eks-cluster"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster_role.name
+}
+

--- a/modules/eks_standalone/outputs.tf
+++ b/modules/eks_standalone/outputs.tf
@@ -1,0 +1,9 @@
+output "endpoint" {
+  value = aws_eks_cluster.cluster.endpoint
+}
+
+output "kubeconfig-certificate-authority-data" {
+  value = aws_eks_cluster.cluster.certificate_authority.0.data
+}
+
+

--- a/modules/eks_standalone/variables.tf
+++ b/modules/eks_standalone/variables.tf
@@ -1,0 +1,28 @@
+variable "k8s_version" {}
+
+variable "cluster_name" {
+  description = "The name of your cluster. Also annotates associated resources."
+}
+
+# Note: Subnets MUST satisfy EKS networking prerequisites. For example, there must be
+# route tables, a route to the internet, and a NAT gateway accessible to private subnets.
+#
+# See:
+# https://aws.amazon.com/blogs/containers/de-mystifying-cluster-networking-for-amazon-eks-worker-nodes/
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "A list of private subnet ids that our EKS node group will use."
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  description = "A list of public subnet ids. One of these will be used for LoadBalancer services"
+}
+
+variable "instance_types" {
+  type = list(string)
+}
+
+variable "num_workers" {
+  type = number
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,8 @@
+
+output "public_subnet_ids" {
+  value = [aws_subnet.public1.id, aws_subnet.public2.id]
+}
+
+output "private_subnet_ids" {
+  value = [aws_subnet.private1.id, aws_subnet.private2.id]
+}

--- a/modules/network/subnet.tf
+++ b/modules/network/subnet.tf
@@ -1,0 +1,135 @@
+
+
+resource "aws_internet_gateway" "gw" {
+  count  = var.internet_gateway
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "${var.network_name}_igw"
+  }
+}
+
+
+resource "aws_route_table" "public_rt" {
+
+  # Only create a route to the internet if the internet gateway exists
+  count = var.internet_gateway
+
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw[count.index].id
+  }
+
+  tags = {
+    Name = "${var.network_name}_public_rt"
+  }
+}
+
+resource "aws_route_table_association" "public1_rt_assoc" {
+  # Only create route table association if the internet gateway exists
+  count          = var.internet_gateway
+  route_table_id = aws_route_table.public_rt[count.index].id
+  subnet_id      = aws_subnet.public1.id
+}
+
+
+resource "aws_route_table_association" "public2_rt_assoc" {
+  count          = var.internet_gateway
+  route_table_id = aws_route_table.public_rt[count.index].id
+  subnet_id      = aws_subnet.public2.id
+}
+
+resource "aws_route_table" "private_rt" {
+
+  count  = var.nat_gateway
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_gw1[count.index].id
+  }
+
+  tags = {
+    Name = "${var.network_name}_public_rt"
+  }
+}
+
+
+resource "aws_route_table_association" "private1_private_rt" {
+  count          = var.nat_gateway
+  route_table_id = aws_route_table.private_rt[count.index].id
+  subnet_id      = aws_subnet.private1.id
+}
+
+resource "aws_route_table_association" "private2_private_rt" {
+  count          = var.nat_gateway
+  route_table_id = aws_route_table.private_rt[count.index].id
+  subnet_id      = aws_subnet.private2.id
+}
+
+resource "aws_subnet" "public1" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, 2)
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name                                        = "${var.network_name}_public1"
+    "kubernetes.io/cluster/${var.network_name}" = "shared"
+    "kubernetes.io/role/elb"                    = 1
+  }
+}
+
+resource "aws_subnet" "public2" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, 3)
+  availability_zone = "us-east-1b"
+
+  tags = {
+    Name                                        = "${var.network_name}_public2"
+    "kubernetes.io/cluster/${var.network_name}" = "shared"
+  }
+}
+
+resource "aws_subnet" "private1" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, 4)
+  availability_zone       = "us-east-1a"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name                                        = "${var.network_name}_private1"
+    "kubernetes.io/cluster/${var.network_name}" = "shared"
+  }
+}
+
+resource "aws_subnet" "private2" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, 5)
+  availability_zone       = "us-east-1b"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name                                        = "${var.network_name}_private2"
+    "kubernetes.io/cluster/${var.network_name}" = "shared"
+  }
+}
+
+# NAT gateways live on the public subnet
+resource "aws_nat_gateway" "nat_gw1" {
+  count         = var.nat_gateway
+  allocation_id = aws_eip.nat_gw1[count.index].id
+  subnet_id     = aws_subnet.public1.id
+
+  tags = {
+    Name = "${var.network_name}_nat_gw1"
+  }
+}
+
+resource "aws_eip" "nat_gw1" {
+  count = var.nat_gateway
+  vpc   = true
+  tags = {
+    Name = "${var.network_name}_nat_gw1_eip"
+  }
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,35 @@
+# We create two public and two private subnets.
+#
+# Creation of NAT gateway and internet gateway are controlled with variables.
+# By default, they're created. Networks not in use can destroy these
+# to save some money, but leave the VPC network intact.
+#
+# Only create route tables and associations for private subnets
+# if the internet gateway exists
+#
+# Only create a route to the internet from the public subnet
+# if the internet gateway exists
+#
+# The default VPC CIDR -> local route is created implicitly, and cannot be specified in TF.
+
+variable "network_name" {
+  description = "A name for this network and its assets. If you intend to launch an EKS cluster in this vpc, this will be the cluster name."
+}
+
+variable "vpc_cidr" {
+  description = "A /16 CIDR range. Will be divided into /20 subnets."
+}
+
+variable "internet_gateway" {
+  description = "Whether to create an internet gateway. Specify 1 or 0."
+  type        = number
+  default     = 1
+}
+
+variable "nat_gateway" {
+  description = "Whether to create a NAT gateway. Specify 1 or 0."
+  type        = number
+  default     = 1
+}
+
+

--- a/modules/network/vpc.tf
+++ b/modules/network/vpc.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "vpc" {
+  cidr_block = var.vpc_cidr
+  tags = {
+    Name                                        = var.network_name
+    "kubernetes.io/cluster/${var.network_name}" = "shared"
+  }
+}
+
+


### PR DESCRIPTION
Standalone modules could be useful. We could launch non-EKS resources
into VPCs, tear down EKS clusters independently, and optionally maintain
future VPC peering relationships.

This plans fine, but since it's Terraform. Who knows if it will fail at
runtime.
