### PR TITLE
Create 3 persistent VPCs for dev envs

### DIFF
--- a/dev_env.tf
+++ b/dev_env.tf
@@ -3,5 +3,22 @@ module "dev1_network" {
   source       = "./modules/network"
   network_name = "dev1"
   vpc_cidr     = "10.1.0.0/16"
+  # Save money: disable while no EC2s are deployed
+  internet_gateway = 0
+  nat_gateway = 0
 }
 
+module "dev2_network" {
+  source       = "./modules/network"
+  network_name = "dev2"
+  vpc_cidr     = "10.2.0.0/16"
+  # Save money: disable while no EC2s are deployed
+  internet_gateway = 0
+  nat_gateway = 0
+}
+
+module "infra_network" {
+  source       = "./modules/network"
+  network_name = "dev2"
+  vpc_cidr     = "10.3.0.0/16"
+}

--- a/dev_env.tf
+++ b/dev_env.tf
@@ -19,6 +19,6 @@ module "dev2_network" {
 
 module "infra_network" {
   source       = "./modules/network"
-  network_name = "dev2"
+  network_name = "infra"
   vpc_cidr     = "10.3.0.0/16"
 }


### PR DESCRIPTION
To practice bringing EKS clusters up and down, it helps to have
persistent networks to host them.

One of these (dev1) already exists. Here we test setting our nat gateway
and interent gateway booleans to false on an existing network. We want
to be able to do this, becuase these are compute resources that cost
money and aren't needed when there are no clusters or EC2s running in
their VPC.
