### PR TITLE
Disable NAT gateway in infra VPC

### DIFF
--- a/dev_env.tf
+++ b/dev_env.tf
@@ -21,4 +21,6 @@ module "infra_network" {
   source       = "./modules/network"
   network_name = "infra"
   vpc_cidr     = "10.3.0.0/16"
+  # Disable NAT while we clean up other EIPs (NAT Gateways require an EIP)
+  nat_gateway = 0
 }


### PR DESCRIPTION
We have [reached our EIP
limit](https://console.aws.amazon.com/servicequotas/home?region=us-east-1#!/services/ec2/quotas/L-0263D0A3)

I have requested an increase, and we need to clean things up, but TF
applies are blocked unless we remove this NAT gateway.