### PR TITLE
Remove one of the peering relationships

### DIFF
--- a/dev_env.tf
+++ b/dev_env.tf
@@ -31,8 +31,3 @@ module "peer_infra_dev1" {
   to_vpc   = module.dev1_network.vpc_id
 }
 
-module "peer_dev1_infra" {
-  source   = "./modules/peering_relationship"
-  from_vpc = module.dev1_network.vpc_id
-  to_vpc   = module.infra_network.vpc_id
-}


### PR DESCRIPTION
We encountered an error if we set up two peerings between the same two
VPCs, even if only one is the "acceptor" in either case.

Perhaps we only need a single peering relationship, even for
bi-directional traffic.

Refs #36
